### PR TITLE
Change node version to use only Node 20.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-         node-version: [18.x, 16.x, 14.x]
+         node-version: [20.x]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Versions 17 and under of Node.js have been deprecated. For this reason I modified the testing action to use newer version of node